### PR TITLE
Allow ability to pass in `readOnly` in the token data

### DIFF
--- a/tokeninput.js
+++ b/tokeninput.js
@@ -1032,7 +1032,7 @@
 
         }
         else {
-            if ( !this.options.readOnly ) {
+            if ( !this.options.readOnly && !datum.readOnly ) {
                 var removeElement = this._createRemoveElement();
                 this.addEventListener( removeElement, 'click', this.onRemoveTokenClick.bind( this ) );
                 element.appendChild( removeElement );


### PR DESCRIPTION
Allow ability to pass in `.readOnly` in the token data to make a specific token readonly during mass update