### PR TITLE
Add element check to prevent undefined object access

### DIFF
--- a/tokeninput.js
+++ b/tokeninput.js
@@ -885,7 +885,11 @@
 
     T.prototype.selectCompletion = function() {
 
-        var element = this.completionElements[ this.selectedCompletionIndex ];
+        const element = this.completionElements[ this.selectedCompletionIndex ];
+        if ( !element ) {
+            return;
+        }
+
         element.classList.add( 'selected' );
 
         element.parentNode.classList.add( 'hasSelected' );


### PR DESCRIPTION
When adding a short delay before pressing enter to tokenise input a console error sometimes appears.

Added guard to check if element exists before calling methods on it prevents this error.